### PR TITLE
keep all deploys in a single bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,13 @@ jobs:
           profile-name: default
       - run:
           name: Create s3 bucket
-          command: aws s3 mb s3://${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BRANCH}
+          command: aws s3 mb s3://deploys
       - run:
           name: Upload file to S3
-          command: aws s3 sync ./build/ s3://${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BRANCH}/${CIRCLE_BUILD_NUM}/
+          command: aws s3 sync ./build/ s3://deploys/${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BRANCH}/${CIRCLE_BUILD_NUM}/
       - run:
           name: Upload file to S3
-          command: cat ${CIRCLE_BUILD_NUM} > LIVE.txt &&  aws s3 sync LIVE.txt s3://${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BRANCH}
+          command: cat ${CIRCLE_BUILD_NUM} > LIVE.txt &&  aws s3 sync LIVE.txt s3://deploys/${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BRANCH}
 
   deploy_cloudfront:
       executor: aws-cli/default


### PR DESCRIPTION
> By default, you can create up to 100 buckets in each of your AWS accounts. If you need additional buckets, you can increase your account bucket limit to a maximum of 1,000 buckets by submitting a service limit increase. There is no difference in performance whether you use many buckets or just a few. For information about how to increase your bucket limit, see AWS service quotas in the AWS General Reference.

https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html